### PR TITLE
this.getDOMNode() for < 0.13 React; findDOMNode() for >= 0.13

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@
           }
           eventHandler(evt);
         }
-      }(React.findDOMNode(this), this.handleClickOutside));
+      }((typeof this.getDOMNode() === 'object' ? this.getDOMNode() : React.findDOMNode(this)), this.handleClickOutside));
 
       var pos = registeredComponents.length;
       registeredComponents.push(this);


### PR DESCRIPTION
Not sure this check is going to fly with newer versions of React. I'm working on a project that relies on React 0.12. react-onclickoutside was throwing the `Uncaught TypeError: e.findDOMNode is not a function` error. Thought maybe we could check first?
